### PR TITLE
Amend layout header for UG and DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1,5 +1,6 @@
 ---
-layout: page title: Developer Guide
+layout: page
+title: Developer Guide
 ---
 
 ## **Table of Contents**

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,5 +1,6 @@
 ---
-layout: page title: User Guide
+layout: page
+title: User Guide
 ---
 
 **_Welcome to the Pocket Hotel User Guide!_**


### PR DESCRIPTION
Website navbar is missing user guide and developer guide links
![image](https://user-images.githubusercontent.com/25302138/136699311-9a1f852c-da17-47b9-8f04-2ef43c550485.png)

Made changes for the DG and UG to be displayed