### PR TITLE
Fix AddressBookParser and IdentifierContainsKeywordsPredicateTest

### DIFF
--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -38,7 +38,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
-import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.StaffBuilder;
 
 public class AddCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,7 +7,9 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSPORT_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STAFF_ID;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPassportNumbers.PASSPORT_NUMBER_DEFAULT;
 import static seedu.address.testutil.TypicalPassportNumbers.PASSPORT_NUMBER_FIRST_PERSON;
+import static seedu.address.testutil.TypicalStaffIds.STAFF_ID_DEFAULT;
 import static seedu.address.testutil.TypicalStaffIds.STAFF_ID_FIRST_PERSON;
 
 import java.util.Arrays;
@@ -82,8 +84,8 @@ public class AddressBookParserTest {
         Guest guest = new GuestBuilder().build();
         EditGuestDescriptor descriptor = new EditGuestDescriptorBuilder(guest).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + PASSPORT_NUMBER_FIRST_PERSON + " " + GuestUtil.getEditGuestDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(PASSPORT_NUMBER_FIRST_PERSON, descriptor), command);
+                + PASSPORT_NUMBER_DEFAULT + " " + GuestUtil.getEditGuestDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(PASSPORT_NUMBER_DEFAULT, descriptor), command);
     }
 
     @Test
@@ -91,9 +93,9 @@ public class AddressBookParserTest {
         Staff staff = new StaffBuilder().build();
         EditStaffDescriptor descriptor = new EditStaffDescriptorBuilder(staff).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + STAFF_ID_FIRST_PERSON + " " + StaffUtil.getEditStaffDescriptorDetails(descriptor));
-        assertEquals(new EditCommand(STAFF_ID_FIRST_PERSON, descriptor), command);
-    } 
+                + STAFF_ID_DEFAULT.toString() + " " + StaffUtil.getEditStaffDescriptorDetails(descriptor));
+        assertEquals(new EditCommand(STAFF_ID_DEFAULT, descriptor), command);
+    }
 
     @Test
     public void parseCommand_exit() throws Exception {

--- a/src/test/java/seedu/address/model/person/IdentifierContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/IdentifierContainsKeywordsPredicateTest.java
@@ -2,6 +2,10 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPassportNumbers.PASSPORT_NUMBER_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPassportNumbers.PASSPORT_NUMBER_SECOND_PERSON;
+import static seedu.address.testutil.TypicalStaffIds.STAFF_ID_FIRST_PERSON;
+import static seedu.address.testutil.TypicalStaffIds.STAFF_ID_SECOND_PERSON;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,14 +23,17 @@ public class IdentifierContainsKeywordsPredicateTest {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        IdentifierContainsKeywordsPredicate firstPredicate = new IdentifierContainsKeywordsPredicate(firstPredicateKeywordList);
-        IdentifierContainsKeywordsPredicate secondPredicate = new IdentifierContainsKeywordsPredicate(secondPredicateKeywordList);
+        IdentifierContainsKeywordsPredicate firstPredicate =
+                new IdentifierContainsKeywordsPredicate(firstPredicateKeywordList);
+        IdentifierContainsKeywordsPredicate secondPredicate =
+                new IdentifierContainsKeywordsPredicate(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        IdentifierContainsKeywordsPredicate firstPredicateCopy = new IdentifierContainsKeywordsPredicate(firstPredicateKeywordList);
+        IdentifierContainsKeywordsPredicate firstPredicateCopy =
+                new IdentifierContainsKeywordsPredicate(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -41,46 +48,58 @@ public class IdentifierContainsKeywordsPredicateTest {
 
     @Test
     public void test_identifierContainsKeywords_returnsTrue() {
-        // Test for Guest 
-        IdentifierContainsKeywordsPredicate predicate = new IdentifierContainsKeywordsPredicate(Collections.singletonList("T1231231D"));
-        assertTrue(predicate.test(new GuestBuilder().withPassportNumber("T1231231D").build()));
+        // Test for Guest
+        IdentifierContainsKeywordsPredicate predicate = new IdentifierContainsKeywordsPredicate(
+                Collections.singletonList(PASSPORT_NUMBER_FIRST_PERSON.toString()));
+        assertTrue(predicate.test(
+                new GuestBuilder().withPassportNumber(PASSPORT_NUMBER_FIRST_PERSON.toString()).build()));
 
-        predicate = new IdentifierContainsKeywordsPredicate(Collections.singletonList("t1231231D"));
-        assertTrue(predicate.test(new GuestBuilder().withPassportNumber("T1231231D").build()));
+        predicate = new IdentifierContainsKeywordsPredicate(
+                Collections.singletonList(PASSPORT_NUMBER_SECOND_PERSON.toString()));
+        assertTrue(predicate.test(
+                new GuestBuilder().withPassportNumber(PASSPORT_NUMBER_SECOND_PERSON.toString()).build()));
 
         // Test for Staff
-        predicate = new IdentifierContainsKeywordsPredicate(Collections.singletonList("123"));
-        assertTrue(predicate.test(new StaffBuilder().withStaffId("123").build()));
+        predicate = new IdentifierContainsKeywordsPredicate(
+                Collections.singletonList(STAFF_ID_FIRST_PERSON.toString()));
+        assertTrue(predicate.test(
+                new StaffBuilder().withStaffId(STAFF_ID_FIRST_PERSON.toString()).build()));
 
-        predicate = new IdentifierContainsKeywordsPredicate(Collections.singletonList("s123"));
-        assertTrue(predicate.test(new StaffBuilder().withStaffId("S123").build())); 
+        predicate = new IdentifierContainsKeywordsPredicate(
+                Collections.singletonList(STAFF_ID_SECOND_PERSON.toString()));
+        assertTrue(predicate.test(
+                new StaffBuilder().withStaffId(STAFF_ID_SECOND_PERSON.toString()).build()));
 
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        IdentifierContainsKeywordsPredicate predicate = new IdentifierContainsKeywordsPredicate(Collections.emptyList());
-        assertFalse(predicate.test(new StaffBuilder().withStaffId("123").build()));
+        IdentifierContainsKeywordsPredicate predicate =
+                new IdentifierContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new StaffBuilder().withStaffId(STAFF_ID_FIRST_PERSON.toString()).build()));
 
         predicate = new IdentifierContainsKeywordsPredicate(Collections.emptyList());
-        assertTrue(predicate.test(new GuestBuilder().withPassportNumber("T1231231D").build())); 
+        assertFalse(predicate.test(
+                new GuestBuilder().withPassportNumber(PASSPORT_NUMBER_FIRST_PERSON.toString()).build()));
 
         // Non-matching keyword
-        predicate = new IdentifierContainsKeywordsPredicate(Arrays.asList("001"));
-        assertFalse(predicate.test(new StaffBuilder().withStaffId("002").build()));
+        predicate = new IdentifierContainsKeywordsPredicate(Arrays.asList(STAFF_ID_FIRST_PERSON.toString()));
+        assertFalse(predicate.test(new StaffBuilder().withStaffId(STAFF_ID_SECOND_PERSON.toString()).build()));
 
-        predicate = new IdentifierContainsKeywordsPredicate(Collections.singletonList("S32131231E"));
-        assertFalse(predicate.test(new GuestBuilder().withPassportNumber("T1231231D").build()));
+        predicate = new IdentifierContainsKeywordsPredicate(
+                Collections.singletonList(PASSPORT_NUMBER_FIRST_PERSON.toString()));
+        assertFalse(predicate.test(new GuestBuilder().withPassportNumber(
+                PASSPORT_NUMBER_SECOND_PERSON.toString()).build()));
 
-        // Keywords match name, email and other respective fields, but does not match identifier 
-        predicate = new IdentifierContainsKeywordsPredicate(Arrays.asList("Alice", "12345", "alice@email.com", "Main", "Street"));
+        // Keywords match name, email and other respective fields, but does not match identifier
+        predicate = new IdentifierContainsKeywordsPredicate(Arrays.asList("Alice", "12345",
+                "alice@email.com", "Main", "Street"));
         assertFalse(predicate.test(new StaffBuilder().withName("Alice").withPhone("12345")
                 .withEmail("alice@email.com").withAddress("Main Street").withStaffId("123").build()));
 
         predicate = new IdentifierContainsKeywordsPredicate(Arrays.asList("Alice", "12345", "alice@email.com"));
         assertFalse(predicate.test(new GuestBuilder().withName("Alice").withRoomNumber("12345")
-                .withEmail("alice@email.com").withPassportNumber("T12312123E").build())); 
-        
+                .withEmail("alice@email.com").withPassportNumber("T12312123E").build()));
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -14,6 +14,7 @@ import static seedu.address.testutil.TypicalPersons.DANIEL_STAFF;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.StaffBuilder;
 
 public class PersonTest {
@@ -38,14 +39,14 @@ public class PersonTest {
         assertTrue(FIONA_STAFF.isSamePerson(editedFiona));
 
         // different SID, all other attributes same -> returns false
-        editedFiona = new StaffBuilder(FIONA_STAFF).withName(VALID_SID_BOB).build();
+        editedFiona = new StaffBuilder(FIONA_STAFF).withStaffId(VALID_SID_BOB).build();
         assertFalse(FIONA_STAFF.isSamePerson(editedFiona));
 
-        // name differs in case, all other attributes same -> returns false
+//        // name differs in case, all other attributes same -> returns false
 //        Person editedBob = new StaffBuilder(FIONA_STAFF).withStaffId(VALID_NAME_BOB.toLowerCase()).build();
 //        assertFalse(BOB.isSamePerson(editedBob));
-
-        // name has trailing spaces, all other attributes same -> returns false
+//
+//        // name has trailing spaces, all other attributes same -> returns false
 //        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
 //        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
 //        assertFalse(BOB.isSamePerson(editedBob));

--- a/src/test/java/seedu/address/testutil/GuestBuilder.java
+++ b/src/test/java/seedu/address/testutil/GuestBuilder.java
@@ -1,10 +1,11 @@
 package seedu.address.testutil;
 
+import static seedu.address.testutil.TypicalPassportNumbers.PASSPORT_NUMBER_DEFAULT;
+
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Guest;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.PassportNumber;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.RoomNumber;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
@@ -14,7 +15,7 @@ public class GuestBuilder extends PersonBuilder {
     private PassportNumber passportNumber;
 
     public static final RoomNumber DEFAULT_ROOM_NUMBER = new RoomNumber("10101");
-    public static final PassportNumber DEFAULT_PASSPORT_NUMBER = new PassportNumber("E0123122G");
+    public static final PassportNumber DEFAULT_PASSPORT_NUMBER = new PassportNumber(PASSPORT_NUMBER_DEFAULT.toString());
 
     private final Tag DEFAULT_TAG = new Tag("Guest");
 

--- a/src/test/java/seedu/address/testutil/StaffBuilder.java
+++ b/src/test/java/seedu/address/testutil/StaffBuilder.java
@@ -9,15 +9,17 @@ import seedu.address.model.person.StaffId;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
+import static seedu.address.testutil.TypicalStaffIds.STAFF_ID_DEFAULT;
+
 public class StaffBuilder extends PersonBuilder {
     private Address address;
     private StaffId staffId;
     private Phone phone;
 
     public static final Address DEFAULT_ADDRESS = new Address("123, Jurong West Ave 6, #08-111");
-    public static final StaffId DEFAULT_STAFF_ID = new StaffId("321");
-    public static final Phone DEFAULT_PHONE = new Phone("85355255");
+    public static final StaffId DEFAULT_STAFF_ID = new StaffId(STAFF_ID_DEFAULT.toString());
     public static final Tag DEFAULT_TAG = new Tag("Staff");
+    public static final Phone DEFAULT_PHONE = new Phone("85355255");
 
     /**
      * Creates a {@code StaffBuilder} with the default details.

--- a/src/test/java/seedu/address/testutil/TypicalPassportNumbers.java
+++ b/src/test/java/seedu/address/testutil/TypicalPassportNumbers.java
@@ -7,4 +7,6 @@ public class TypicalPassportNumbers {
     public static final PassportNumber PASSPORT_NUMBER_SECOND_PERSON = new PassportNumber("T12312311A");
     public static final PassportNumber PASSPORT_NUMBER_THIRD_PERSON = new PassportNumber("M123123124D");
     public static final PassportNumber PASSPORT_NUMBER_UNUSED = new PassportNumber("L21312314H");
+    // Default passport number used in builders
+    public static final PassportNumber PASSPORT_NUMBER_DEFAULT = new PassportNumber("A163812686D");
 }

--- a/src/test/java/seedu/address/testutil/TypicalStaffIds.java
+++ b/src/test/java/seedu/address/testutil/TypicalStaffIds.java
@@ -8,4 +8,6 @@ public class TypicalStaffIds {
     public static final StaffId STAFF_ID_THIRD_PERSON = new StaffId("777");
     public static final StaffId STAFF_ID_FOURTH_PERSON = new StaffId("888");
     public static final StaffId STAFF_ID_UNUSED = new StaffId("999");
+    // Default passport number used in builders
+    public static final StaffId STAFF_ID_DEFAULT = new StaffId("98765");
 }


### PR DESCRIPTION
Fix 
- AddressBookParserTest
- IdentifierContainsKeywordsPredicateTest
- Refactor tests to use TypicalPassportNumber and TypicalStaffId